### PR TITLE
fix: 道路建設カード使用時に資源を消費しないよう修正

### DIFF
--- a/app/components/GameRoom.tsx
+++ b/app/components/GameRoom.tsx
@@ -71,6 +71,8 @@ const PHASE_LABELS: Record<GamePhase, string> = {
   robber_steal: "資源を奪う",
   discard: "資源を破棄",
   trade_offer: "交易提案中",
+  road_building_1: "街道建設（1本目）",
+  road_building_2: "街道建設（2本目）",
   game_over: "ゲーム終了",
 };
 
@@ -1586,6 +1588,15 @@ function ActionPanel({
             </p>
           )}
 
+        {/* 街道建設カードフェーズ */}
+        {(phase === "road_building_1" || phase === "road_building_2") &&
+          isMyTurn && (
+            <p className="text-sm text-gray-600">
+              街道建設カード: {phase === "road_building_1" ? "1本目" : "2本目"}
+              の道を配置する場所をクリックしてください（資源消費なし）
+            </p>
+          )}
+
         {/* 盗賊移動フェーズ */}
         {phase === "robber_move" && isMyTurn && (
           <p className="text-sm text-gray-600">
@@ -2003,8 +2014,13 @@ export function GameRoom() {
       return gameState.edges.filter((e) => !e.road).map((e) => e.id);
     }
 
-    // メインフェーズ: 空き辺
-    if (isMyTurn && phase === "main") {
+    // メインフェーズと街道建設フェーズ: 空き辺
+    if (
+      isMyTurn &&
+      (phase === "main" ||
+        phase === "road_building_1" ||
+        phase === "road_building_2")
+    ) {
       return gameState.edges.filter((e) => !e.road).map((e) => e.id);
     }
 
@@ -2067,7 +2083,9 @@ export function GameRoom() {
       if (
         phase === "setup_road_1" ||
         phase === "setup_road_2" ||
-        phase === "main"
+        phase === "main" ||
+        phase === "road_building_1" ||
+        phase === "road_building_2"
       ) {
         playSound("build");
         sendAction({ type: "build_road", edgeId } as Omit<GameAction, "roomId">);

--- a/server/game-logic.ts
+++ b/server/game-logic.ts
@@ -1150,6 +1150,8 @@ export function handleBuildRoad(
 
   const isSetupPhase =
     state.phase === "setup_road_1" || state.phase === "setup_road_2";
+  const isRoadBuildingPhase =
+    state.phase === "road_building_1" || state.phase === "road_building_2";
 
   // 辺の座標を解析
   const edgeCoord = parseEdgeId(edgeId);
@@ -1201,16 +1203,18 @@ export function handleBuildRoad(
       throw new Error("道は直前に配置した開拓地に隣接している必要があります");
     }
   } else {
-    if (state.phase !== "main") {
+    if (state.phase !== "main" && !isRoadBuildingPhase) {
       throw new Error("Cannot build in current phase");
     }
 
-    // コスト確認（wood:1, brick:1）
-    if (player.resources.wood < 1 || player.resources.brick < 1) {
-      throw new Error("Not enough resources");
+    // コスト確認（wood:1, brick:1）- 街道建設カードフェーズでは不要
+    if (!isRoadBuildingPhase) {
+      if (player.resources.wood < 1 || player.resources.brick < 1) {
+        throw new Error("Not enough resources");
+      }
     }
 
-    // メインフェーズでは自分の道または建物に隣接している必要がある
+    // メインフェーズと街道建設フェーズでは自分の道または建物に隣接している必要がある
     const hasConnection = adjacentVertexIds.some((vertexId) => {
       // 建物に隣接しているか
       const intersection = state.intersections.find((i) => i.id === vertexId);
@@ -1249,7 +1253,8 @@ export function handleBuildRoad(
     if (p.id !== playerId) return p;
 
     let updatedResources = { ...p.resources };
-    if (!isSetupPhase) {
+    // 初期配置フェーズと街道建設カードフェーズでは資源を消費しない
+    if (!isSetupPhase && !isRoadBuildingPhase) {
       updatedResources = {
         ...updatedResources,
         wood: updatedResources.wood - 1,
@@ -1290,6 +1295,12 @@ export function handleBuildRoad(
       nextPhase = "setup_settlement_2";
       nextPlayerId = state.turnOrder[currentIndex - 1];
     }
+  } else if (state.phase === "road_building_1") {
+    // 街道建設カード: 1本目の道を建設したら2本目へ
+    nextPhase = "road_building_2";
+  } else if (state.phase === "road_building_2") {
+    // 街道建設カード: 2本目の道を建設したらメインフェーズへ戻る
+    nextPhase = "main";
   }
 
   let newState: GameState = {
@@ -1829,26 +1840,19 @@ export function handleUseDevelopmentCard(
     }
 
     case "roadBuilding": {
-      // 街道建設: 2本の道を無料で建設（後でUIで処理）
+      // 街道建設: 2本の道を無料で建設
       updatedPlayers = state.players.map((p) => {
         if (p.id !== playerId) return p;
         const newCards = [...p.developmentCards];
         newCards.splice(cardIndex, 1);
         return { ...p, developmentCards: newCards };
       });
-      // 実際の道建設は別途処理（簡易実装: 道2本分の資源を付与）
-      updatedPlayers = updatedPlayers.map((p) => {
-        if (p.id !== playerId) return p;
-        return {
-          ...p,
-          resources: {
-            ...p.resources,
-            wood: p.resources.wood + 2,
-            brick: p.resources.brick + 2,
-          },
-        };
-      });
-      updatedState = { ...state, players: updatedPlayers };
+      // 道建設フェーズに移行（資源消費なしで2本の道を建設）
+      updatedState = {
+        ...state,
+        players: updatedPlayers,
+        phase: "road_building_1" as GamePhase,
+      };
       break;
     }
 

--- a/types/game.ts
+++ b/types/game.ts
@@ -205,6 +205,8 @@ export type GamePhase =
   | "robber_steal" // 盗賊による資源略奪
   | "discard" // 資源破棄（7が出た時、8枚以上持っている場合）
   | "trade_offer" // 交易提案中
+  | "road_building_1" // 街道建設カード：1本目の道を建設
+  | "road_building_2" // 街道建設カード：2本目の道を建設
   | "game_over"; // ゲーム終了
 
 /**


### PR DESCRIPTION
道路建設カードを使用した際に、以前の簡易実装では木材2・煉瓦2を
追加していたため、その後の道路建設時に資源が消費されていました。

新しいゲームフェーズ（road_building_1, road_building_2）を追加し、
このフェーズでは道路建設時に資源を消費しないように修正しました。