### PR TITLE
feat: Add AI CPU player support for server-side AI gameplay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,9 @@ NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
 NEXT_PUBLIC_DEBUG_BOARD=false  # true にするとボード上に頂点座標を表示
 
 # AI CPU プレイヤー設定
-AI_PROVIDER=gemini  # "gemini" または "deepseek"
+AI_PROVIDER=gemini  # "gemini", "deepseek", または "openrouter"
 GEMINI_API_KEY=your_gemini_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
-AI_MODEL=  # 空の場合はプロバイダーのデフォルトモデル (gemini-2.0-flash-exp / deepseek-chat)
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+AI_MODEL=  # 空の場合はプロバイダーのデフォルトモデル (gemini-2.0-flash-exp / deepseek-chat / google/gemini-2.0-flash-exp:free)
 AI_THINKING_DELAY=1500  # AIの思考時間（ミリ秒）- 人間らしさのための遅延

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
 
 # デバッグ設定
 NEXT_PUBLIC_DEBUG_BOARD=false  # true にするとボード上に頂点座標を表示
+
+# AI CPU プレイヤー設定
+AI_PROVIDER=gemini  # "gemini" または "deepseek"
+GEMINI_API_KEY=your_gemini_api_key_here
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+AI_MODEL=  # 空の場合はプロバイダーのデフォルトモデル (gemini-2.0-flash-exp / deepseek-chat)
+AI_THINKING_DELAY=1500  # AIの思考時間（ミリ秒）- 人間らしさのための遅延

--- a/app/components/GameRoom.tsx
+++ b/app/components/GameRoom.tsx
@@ -741,6 +741,7 @@ function PlayerPanel({
     >
       <div className="flex items-center justify-between mb-2">
         <span className="font-semibold text-gray-800">
+          {player.isAI && <span title="CPUプレイヤー">🤖 </span>}
           {player.name}
           {isSelf && " (あなた)"}
         </span>
@@ -842,6 +843,8 @@ function ActionPanel({
   onResetGame,
   onTakeSeat,
   onLeaveSeat,
+  onAddCpuPlayer,
+  onRemoveCpuPlayer,
 }: {
   gameState: GameState;
   playerId: string;
@@ -850,6 +853,8 @@ function ActionPanel({
   onResetGame: () => void;
   onTakeSeat: () => void;
   onLeaveSeat: () => void;
+  onAddCpuPlayer?: () => void;
+  onRemoveCpuPlayer?: (cpuPlayerId: string) => void;
 }) {
   const isMyTurn = gameState.currentPlayerId === playerId;
   const phase = gameState.phase;
@@ -1104,6 +1109,34 @@ function ActionPanel({
           )
         )}
 
+        {/* CPU追加ボタン（ホストのみ） */}
+        {isHost && !isSpectator && gameState.players.length < 4 && onAddCpuPlayer && (
+          <button
+            onClick={onAddCpuPlayer}
+            className="w-full py-2 bg-purple-600 text-white rounded-lg font-semibold hover:bg-purple-700 transition"
+          >
+            + CPUプレイヤーを追加
+          </button>
+        )}
+
+        {/* CPUプレイヤー一覧と削除ボタン（ホストのみ） */}
+        {isHost && !isSpectator && gameState.players.filter(p => p.isAI).length > 0 && onRemoveCpuPlayer && (
+          <div className="bg-purple-50 p-2 rounded-lg space-y-1">
+            <p className="text-xs text-purple-700 font-medium">CPUプレイヤー:</p>
+            {gameState.players.filter(p => p.isAI).map(cpu => (
+              <div key={cpu.id} className="flex items-center justify-between">
+                <span className="text-sm text-purple-800">{cpu.name}</span>
+                <button
+                  onClick={() => onRemoveCpuPlayer(cpu.id)}
+                  className="px-2 py-0.5 text-xs bg-red-500 text-white rounded hover:bg-red-600 transition"
+                >
+                  削除
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
         {/* ゲーム開始ボタン（プレイヤーのみ） */}
         {!isSpectator && canStartGame && (
           <button
@@ -1116,7 +1149,7 @@ function ActionPanel({
 
         {!isSpectator && gameState.players.length < 3 && (
           <p className="text-xs text-gray-500">
-            ゲームを開始するには3人以上必要です
+            ゲームを開始するには3人以上必要です（CPUも追加可能）
           </p>
         )}
 
@@ -1913,6 +1946,8 @@ export function GameRoom() {
     sendChatMessage,
     resetGame,
     clearSavedSession,
+    addCpuPlayer,
+    removeCpuPlayer,
   } = useGameSocket();
 
   // ゲーム設定（効果音・通知）
@@ -2281,6 +2316,8 @@ export function GameRoom() {
                 onResetGame={resetGame}
                 onTakeSeat={takeSeat}
                 onLeaveSeat={leaveSeat}
+                onAddCpuPlayer={addCpuPlayer}
+                onRemoveCpuPlayer={removeCpuPlayer}
               />
             )}
             {/* ゲームログ */}

--- a/app/hooks/useGameSocket.ts
+++ b/app/hooks/useGameSocket.ts
@@ -96,6 +96,10 @@ export interface UseGameSocketReturn {
   reconnect: () => void;
   /** 保存されたセッションをクリア */
   clearSavedSession: () => void;
+  /** CPUプレイヤーを追加（ホストのみ） */
+  addCpuPlayer: () => void;
+  /** CPUプレイヤーを削除（ホストのみ） */
+  removeCpuPlayer: (cpuPlayerId: string) => void;
 }
 
 // ============================================
@@ -408,6 +412,22 @@ export function useGameSocket(
       setError(data.message);
     });
 
+    socket.on("cpu_player_added", (data) => {
+      console.log("[useGameSocket] CPU player added:", data);
+      if (!data.success) {
+        setError(data.error || "CPUプレイヤーの追加に失敗しました");
+        setTimeout(() => setError(null), 3000);
+      }
+    });
+
+    socket.on("cpu_player_removed", (data) => {
+      console.log("[useGameSocket] CPU player removed:", data);
+      if (!data.success) {
+        setError(data.error || "CPUプレイヤーの削除に失敗しました");
+        setTimeout(() => setError(null), 3000);
+      }
+    });
+
     socketRef.current = socket;
     return socket;
   }, [serverUrl]);
@@ -625,6 +645,33 @@ export function useGameSocket(
   }, []);
 
   /**
+   * CPUプレイヤーを追加（ホストのみ）
+   */
+  const addCpuPlayer = useCallback(() => {
+    if (!socketRef.current || !roomIdRef.current) {
+      setError("サーバーに接続されていません");
+      return;
+    }
+
+    socketRef.current.emit("add_cpu_player", { roomId: roomIdRef.current });
+  }, []);
+
+  /**
+   * CPUプレイヤーを削除（ホストのみ）
+   */
+  const removeCpuPlayer = useCallback((cpuPlayerId: string) => {
+    if (!socketRef.current || !roomIdRef.current) {
+      setError("サーバーに接続されていません");
+      return;
+    }
+
+    socketRef.current.emit("remove_cpu_player", {
+      roomId: roomIdRef.current,
+      playerId: cpuPlayerId,
+    });
+  }, []);
+
+  /**
    * 接続を再試行
    */
   const reconnect = useCallback(() => {
@@ -687,6 +734,8 @@ export function useGameSocket(
     resetGame,
     reconnect,
     clearSavedSession,
+    addCpuPlayer,
+    removeCpuPlayer,
   };
 }
 

--- a/server/ai/ai-client.ts
+++ b/server/ai/ai-client.ts
@@ -1,6 +1,6 @@
 /**
  * AI クライアント
- * Gemini / DeepSeek API を使用してゲームアクションを決定
+ * Gemini / DeepSeek / OpenRouter API を使用してゲームアクションを決定
  */
 
 import {
@@ -16,12 +16,14 @@ import { CATAN_RULES, CATAN_STRATEGY } from "../mcp/resources";
 const DEFAULT_MODELS: Record<AIProvider, string> = {
   gemini: "gemini-2.0-flash-exp",
   deepseek: "deepseek-chat",
+  openrouter: "google/gemini-2.0-flash-exp:free",
 };
 
 // API エンドポイント
 const API_ENDPOINTS: Record<AIProvider, string> = {
   gemini: "https://generativelanguage.googleapis.com/v1beta/models",
   deepseek: "https://api.deepseek.com/v1/chat/completions",
+  openrouter: "https://openrouter.ai/api/v1/chat/completions",
 };
 
 /**
@@ -175,6 +177,8 @@ JSONで回答してください。以下の形式のみ使用可能です:
   private async callAPI(prompt: string): Promise<string> {
     if (this.config.provider === "gemini") {
       return this.callGeminiAPI(prompt);
+    } else if (this.config.provider === "openrouter") {
+      return this.callOpenRouterAPI(prompt);
     } else {
       return this.callDeepSeekAPI(prompt);
     }
@@ -267,6 +271,58 @@ JSONで回答してください。以下の形式のみ使用可能です:
 
     if (!text) {
       throw new Error("No response from DeepSeek API");
+    }
+
+    return text;
+  }
+
+  /**
+   * OpenRouter API を呼び出し
+   * OpenAI互換のAPIフォーマットを使用
+   */
+  private async callOpenRouterAPI(prompt: string): Promise<string> {
+    const url = API_ENDPOINTS.openrouter;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.config.apiKey}`,
+        "HTTP-Referer": "https://github.com/omatztw/cc-catado",
+        "X-Title": "Catan AI Player",
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages: [
+          {
+            role: "system",
+            content:
+              "あなたはカタンをプレイするAIです。JSONで回答してください。",
+          },
+          {
+            role: "user",
+            content: prompt,
+          },
+        ],
+        temperature: 0.7,
+        max_tokens: 1024,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OpenRouter API error: ${response.status} - ${errorText}`);
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{
+        message?: { content?: string };
+      }>;
+    };
+    const text = data.choices?.[0]?.message?.content;
+
+    if (!text) {
+      throw new Error("No response from OpenRouter API");
     }
 
     return text;
@@ -375,10 +431,18 @@ export function getAIClient(): AIClient | null {
 
   // 環境変数から設定を読み込み
   const provider = (process.env.AI_PROVIDER as AIProvider) || "gemini";
-  const apiKey =
-    provider === "gemini"
-      ? process.env.GEMINI_API_KEY
-      : process.env.DEEPSEEK_API_KEY;
+  let apiKey: string | undefined;
+  switch (provider) {
+    case "gemini":
+      apiKey = process.env.GEMINI_API_KEY;
+      break;
+    case "deepseek":
+      apiKey = process.env.DEEPSEEK_API_KEY;
+      break;
+    case "openrouter":
+      apiKey = process.env.OPENROUTER_API_KEY;
+      break;
+  }
 
   if (!apiKey) {
     console.warn(

--- a/server/ai/ai-client.ts
+++ b/server/ai/ai-client.ts
@@ -1,0 +1,406 @@
+/**
+ * AI クライアント
+ * Gemini / DeepSeek API を使用してゲームアクションを決定
+ */
+
+import {
+  type AIConfig,
+  type AIProvider,
+  type GameState,
+  type GameAction,
+  type AvailableAction,
+} from "../../types/game";
+import { CATAN_RULES, CATAN_STRATEGY } from "../mcp/resources";
+
+// デフォルトモデル
+const DEFAULT_MODELS: Record<AIProvider, string> = {
+  gemini: "gemini-2.0-flash-exp",
+  deepseek: "deepseek-chat",
+};
+
+// API エンドポイント
+const API_ENDPOINTS: Record<AIProvider, string> = {
+  gemini: "https://generativelanguage.googleapis.com/v1beta/models",
+  deepseek: "https://api.deepseek.com/v1/chat/completions",
+};
+
+/**
+ * AI クライアントクラス
+ */
+export class AIClient {
+  private config: AIConfig;
+
+  constructor(config: AIConfig) {
+    this.config = {
+      ...config,
+      model: config.model || DEFAULT_MODELS[config.provider],
+      thinkingDelay: config.thinkingDelay ?? 1000,
+    };
+  }
+
+  /**
+   * ゲーム状態と利用可能なアクションからAIの決定を取得
+   */
+  async decideAction(
+    gameState: GameState,
+    playerId: string,
+    availableActions: AvailableAction[]
+  ): Promise<GameAction | null> {
+    const prompt = this.buildPrompt(gameState, playerId, availableActions);
+
+    try {
+      const response = await this.callAPI(prompt);
+      const action = this.parseResponse(response, gameState.id, availableActions);
+
+      // 人間らしさのための遅延
+      if (this.config.thinkingDelay && this.config.thinkingDelay > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, this.config.thinkingDelay)
+        );
+      }
+
+      return action;
+    } catch (error) {
+      console.error("[AIClient] Error deciding action:", error);
+      return null;
+    }
+  }
+
+  /**
+   * プロンプトを構築
+   */
+  private buildPrompt(
+    gameState: GameState,
+    playerId: string,
+    availableActions: AvailableAction[]
+  ): string {
+    const player = gameState.players.find((p) => p.id === playerId);
+    if (!player) {
+      throw new Error(`Player ${playerId} not found`);
+    }
+
+    // ゲーム状態のサマリーを作成
+    const stateSummary = this.buildStateSummary(gameState, player);
+
+    // 利用可能なアクションをJSON形式で
+    const actionsJson = JSON.stringify(availableActions, null, 2);
+
+    return `あなたはカタンをプレイするAIです。以下のルールと戦略を理解し、最適なアクションを選択してください。
+
+## ゲームルール
+${CATAN_RULES}
+
+## 戦略ガイド
+${CATAN_STRATEGY}
+
+## 現在のゲーム状態
+
+${stateSummary}
+
+## あなたの情報
+- プレイヤー名: ${player.name}
+- 色: ${player.color}
+- 資源: 木材=${player.resources.wood}, レンガ=${player.resources.brick}, 小麦=${player.resources.wheat}, 鉱石=${player.resources.ore}, 羊毛=${player.resources.sheep}
+- 発展カード: ${player.developmentCards.length}枚
+- 使用済み騎士: ${player.knightsPlayed}枚
+- 勝利点(公開): ${player.visibleVictoryPoints}
+
+## 利用可能なアクション
+以下のアクションから1つを選択してください:
+
+${actionsJson}
+
+## 回答形式
+JSONで回答してください。以下の形式のみ使用可能です:
+
+{"action": {"type": "アクション名", ...必要なパラメータ}, "reasoning": "選択理由"}
+
+重要:
+- 必ず上記の利用可能なアクションリストから選択してください
+- type以外に必要なパラメータは、上記リストのparamsを参照してください
+- roomIdは不要です（自動で追加されます）
+- reasoningは日本語で簡潔に記載してください
+`;
+  }
+
+  /**
+   * ゲーム状態のサマリーを構築
+   */
+  private buildStateSummary(
+    gameState: GameState,
+    currentPlayer: { id: string }
+  ): string {
+    const phase = gameState.phase;
+    const turnNumber = gameState.turnNumber;
+    const diceResult = gameState.diceResult;
+
+    let summary = `- フェーズ: ${phase}\n`;
+    summary += `- ターン番号: ${turnNumber}\n`;
+
+    if (diceResult) {
+      summary += `- 直前のサイコロ: ${diceResult.die1} + ${diceResult.die2} = ${diceResult.total}\n`;
+    }
+
+    summary += `\n### 各プレイヤーの状況:\n`;
+    for (const p of gameState.players) {
+      const isMe = p.id === currentPlayer.id;
+      const marker = isMe ? "（あなた）" : "";
+      summary += `- ${p.name}${marker} [${p.color}]: 勝利点=${p.visibleVictoryPoints}, `;
+      summary += `開拓地残=${p.remainingPieces.settlements}, 都市残=${p.remainingPieces.cities}, 道残=${p.remainingPieces.roads}`;
+      if (p.hasLongestRoad) summary += ", 最長交易路";
+      if (p.hasLargestArmy) summary += ", 最大騎士力";
+      summary += "\n";
+    }
+
+    // 建造物情報（簡略化）
+    const buildings = gameState.intersections.filter((i) => i.building);
+    const roads = gameState.edges.filter((e) => e.road);
+
+    summary += `\n### ボード状況:\n`;
+    summary += `- 建造物数: ${buildings.length}（開拓地・都市）\n`;
+    summary += `- 道数: ${roads.length}\n`;
+
+    // 盗賊の位置
+    const robberHex = gameState.hexes.find((h) => h.hasRobber);
+    if (robberHex) {
+      summary += `- 盗賊: ${robberHex.resourceType}タイル（数字${robberHex.numberToken || "なし"}）\n`;
+    }
+
+    return summary;
+  }
+
+  /**
+   * API を呼び出し
+   */
+  private async callAPI(prompt: string): Promise<string> {
+    if (this.config.provider === "gemini") {
+      return this.callGeminiAPI(prompt);
+    } else {
+      return this.callDeepSeekAPI(prompt);
+    }
+  }
+
+  /**
+   * Gemini API を呼び出し
+   */
+  private async callGeminiAPI(prompt: string): Promise<string> {
+    const url = `${API_ENDPOINTS.gemini}/${this.config.model}:generateContent?key=${this.config.apiKey}`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [{ text: prompt }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.7,
+          maxOutputTokens: 1024,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+    }
+
+    const data = (await response.json()) as {
+      candidates?: Array<{
+        content?: { parts?: Array<{ text?: string }> };
+      }>;
+    };
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+
+    if (!text) {
+      throw new Error("No response from Gemini API");
+    }
+
+    return text;
+  }
+
+  /**
+   * DeepSeek API を呼び出し
+   */
+  private async callDeepSeekAPI(prompt: string): Promise<string> {
+    const url = API_ENDPOINTS.deepseek;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        messages: [
+          {
+            role: "system",
+            content:
+              "あなたはカタンをプレイするAIです。JSONで回答してください。",
+          },
+          {
+            role: "user",
+            content: prompt,
+          },
+        ],
+        temperature: 0.7,
+        max_tokens: 1024,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`DeepSeek API error: ${response.status} - ${errorText}`);
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{
+        message?: { content?: string };
+      }>;
+    };
+    const text = data.choices?.[0]?.message?.content;
+
+    if (!text) {
+      throw new Error("No response from DeepSeek API");
+    }
+
+    return text;
+  }
+
+  /**
+   * APIレスポンスをパースしてGameActionを取得
+   */
+  private parseResponse(
+    response: string,
+    roomId: string,
+    availableActions: AvailableAction[]
+  ): GameAction | null {
+    try {
+      // JSON部分を抽出（```json ... ``` や前後のテキストを除去）
+      let jsonStr = response;
+
+      // Markdownコードブロックを除去
+      const jsonMatch = response.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+      if (jsonMatch) {
+        jsonStr = jsonMatch[1];
+      } else {
+        // { } で囲まれた部分を抽出
+        const braceMatch = response.match(/\{[\s\S]*\}/);
+        if (braceMatch) {
+          jsonStr = braceMatch[0];
+        }
+      }
+
+      const parsed = JSON.parse(jsonStr);
+      const actionData = parsed.action || parsed;
+
+      // roomIdを追加
+      const action = {
+        ...actionData,
+        roomId,
+      } as GameAction;
+
+      // アクションが有効かチェック
+      const isValid = availableActions.some((a) => a.type === action.type);
+      if (!isValid) {
+        console.warn(
+          `[AIClient] Invalid action type: ${action.type}. Available: ${availableActions.map((a) => a.type).join(", ")}`
+        );
+        // フォールバック: 最初の利用可能なアクションを選択
+        return this.createFallbackAction(roomId, availableActions);
+      }
+
+      console.log(
+        `[AIClient] AI decided: ${action.type}`,
+        parsed.reasoning || ""
+      );
+      return action;
+    } catch (error) {
+      console.error("[AIClient] Failed to parse AI response:", error);
+      console.error("[AIClient] Response was:", response);
+      return this.createFallbackAction(roomId, availableActions);
+    }
+  }
+
+  /**
+   * フォールバックアクションを作成
+   */
+  private createFallbackAction(
+    roomId: string,
+    availableActions: AvailableAction[]
+  ): GameAction | null {
+    if (availableActions.length === 0) {
+      return null;
+    }
+
+    // 優先順位: end_turn > roll_dice > その他
+    const priorities = ["roll_dice", "end_turn"];
+    for (const priority of priorities) {
+      const action = availableActions.find((a) => a.type === priority);
+      if (action) {
+        console.log(`[AIClient] Fallback action: ${priority}`);
+        return { type: priority, roomId } as GameAction;
+      }
+    }
+
+    // 最初のアクションを選択
+    const firstAction = availableActions[0];
+    console.log(`[AIClient] Fallback to first action: ${firstAction.type}`);
+
+    const baseAction = { type: firstAction.type, roomId };
+
+    // パラメータがある場合は追加
+    if (firstAction.params) {
+      return { ...baseAction, ...firstAction.params } as GameAction;
+    }
+
+    return baseAction as GameAction;
+  }
+}
+
+/**
+ * AIクライアントのシングルトンインスタンスを作成
+ */
+let aiClientInstance: AIClient | null = null;
+
+export function getAIClient(): AIClient | null {
+  if (aiClientInstance) {
+    return aiClientInstance;
+  }
+
+  // 環境変数から設定を読み込み
+  const provider = (process.env.AI_PROVIDER as AIProvider) || "gemini";
+  const apiKey =
+    provider === "gemini"
+      ? process.env.GEMINI_API_KEY
+      : process.env.DEEPSEEK_API_KEY;
+
+  if (!apiKey) {
+    console.warn(
+      `[AIClient] No API key found for ${provider}. AI CPU players will not be available.`
+    );
+    return null;
+  }
+
+  aiClientInstance = new AIClient({
+    provider,
+    apiKey,
+    model: process.env.AI_MODEL,
+    thinkingDelay: parseInt(process.env.AI_THINKING_DELAY || "1500", 10),
+  });
+
+  console.log(`[AIClient] Initialized with ${provider} provider`);
+  return aiClientInstance;
+}
+
+/**
+ * AIクライアントが利用可能かどうか
+ */
+export function isAIAvailable(): boolean {
+  return getAIClient() !== null;
+}

--- a/server/ai/ai-player.ts
+++ b/server/ai/ai-player.ts
@@ -1,0 +1,700 @@
+/**
+ * AI プレイヤー管理
+ * CPUプレイヤーの作成・ターン実行を管理
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import type {
+  GameState,
+  Player,
+  GameAction,
+  AvailableAction,
+  HoldableResource,
+  PlayerColor,
+  DevelopmentCardType,
+} from "../../types/game";
+import { BUILD_COSTS, INITIAL_RESOURCES, INITIAL_PIECES } from "../../types/game";
+import { AIClient, getAIClient, isAIAvailable } from "./ai-client";
+
+// CPUプレイヤー名のプール
+const CPU_NAMES = [
+  "CPU Alice",
+  "CPU Bob",
+  "CPU Carol",
+  "CPU Dave",
+];
+
+// 利用可能な色
+const COLORS: PlayerColor[] = ["red", "blue", "orange", "white"];
+
+/**
+ * CPUプレイヤーを作成
+ */
+export function createCPUPlayer(existingPlayers: Player[]): Player | null {
+  // AIが利用可能かチェック
+  if (!isAIAvailable()) {
+    console.warn("[AIPlayer] AI is not available. Cannot create CPU player.");
+    return null;
+  }
+
+  // 利用可能な色を取得
+  const usedColors = existingPlayers.map((p) => p.color);
+  const availableColors = COLORS.filter((c) => !usedColors.includes(c));
+
+  if (availableColors.length === 0) {
+    console.warn("[AIPlayer] No available colors for CPU player.");
+    return null;
+  }
+
+  // CPUの人数をカウント
+  const cpuCount = existingPlayers.filter((p) => p.isAI).length;
+  const cpuName = CPU_NAMES[cpuCount] || `CPU ${cpuCount + 1}`;
+
+  const player: Player = {
+    id: `cpu_${uuidv4()}`,
+    name: cpuName,
+    color: availableColors[0],
+    resources: { ...INITIAL_RESOURCES },
+    developmentCards: [],
+    knightsPlayed: 0,
+    hasLongestRoad: false,
+    hasLargestArmy: false,
+    visibleVictoryPoints: 0,
+    remainingPieces: { ...INITIAL_PIECES },
+    isConnected: true,
+    isAI: true,
+  };
+
+  console.log(`[AIPlayer] Created CPU player: ${player.name} (${player.id})`);
+  return player;
+}
+
+/**
+ * プレイヤーがAIかどうか
+ */
+export function isAIPlayer(player: Player): boolean {
+  return player.isAI === true;
+}
+
+/**
+ * ゲーム状態からAIプレイヤーの利用可能なアクションを取得
+ */
+export function getAvailableActionsForAI(
+  state: GameState,
+  playerId: string
+): AvailableAction[] {
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return [];
+
+  const isMyTurn = state.currentPlayerId === playerId;
+  const actions: AvailableAction[] = [];
+
+  switch (state.phase) {
+    case "waiting":
+      // AIは自分でゲーム開始しない
+      break;
+
+    case "setup_settlement_1":
+    case "setup_settlement_2":
+      if (isMyTurn) {
+        const validIntersections = getValidSettlementLocations(state, playerId, true);
+        for (const intersection of validIntersections) {
+          actions.push({
+            type: "build_settlement",
+            description: `開拓地を建設 (位置: ${intersection.id})`,
+            params: { intersectionId: intersection.id },
+          });
+        }
+      }
+      break;
+
+    case "setup_road_1":
+    case "setup_road_2":
+      if (isMyTurn) {
+        const validEdges = getValidRoadLocations(state, playerId);
+        for (const edge of validEdges) {
+          actions.push({
+            type: "build_road",
+            description: `道を建設 (位置: ${edge.id})`,
+            params: { edgeId: edge.id },
+          });
+        }
+      }
+      break;
+
+    case "roll_dice":
+      if (isMyTurn) {
+        actions.push({
+          type: "roll_dice",
+          description: "サイコロを振る",
+        });
+      }
+      break;
+
+    case "discard":
+      const totalResources = Object.values(player.resources).reduce(
+        (a, b) => a + b,
+        0
+      );
+      if (totalResources > 7) {
+        const discardCount = Math.floor(totalResources / 2);
+        // 破棄する資源の組み合わせを提案
+        const discardOptions = generateDiscardOptions(player.resources, discardCount);
+        for (const option of discardOptions.slice(0, 5)) {
+          actions.push({
+            type: "discard_resources",
+            description: `資源を${discardCount}枚破棄`,
+            params: { resources: option },
+          });
+        }
+      }
+      break;
+
+    case "robber_move":
+      if (isMyTurn) {
+        const validHexes = getValidRobberLocations(state);
+        for (const hex of validHexes) {
+          actions.push({
+            type: "move_robber",
+            description: `盗賊を移動 (${hex.resourceType}タイル、数字${hex.numberToken || "なし"})`,
+            params: { hexId: hex.id },
+          });
+        }
+      }
+      break;
+
+    case "robber_steal":
+      if (isMyTurn) {
+        const stealTargets = getStealTargets(state, playerId);
+        for (const target of stealTargets) {
+          actions.push({
+            type: "steal_resource",
+            description: `${target.name}から資源を奪う`,
+            params: { targetPlayerId: target.id },
+          });
+        }
+        // 対象がいない場合は空のアクション
+        if (stealTargets.length === 0) {
+          actions.push({
+            type: "steal_resource",
+            description: "奪える対象がいない",
+            params: { targetPlayerId: "" },
+          });
+        }
+      }
+      break;
+
+    case "road_building_1":
+    case "road_building_2":
+      if (isMyTurn) {
+        const validEdges = getValidRoadLocations(state, playerId);
+        for (const edge of validEdges) {
+          actions.push({
+            type: "build_road",
+            description: `道を建設 (位置: ${edge.id})`,
+            params: { edgeId: edge.id },
+          });
+        }
+      }
+      break;
+
+    case "main":
+      if (isMyTurn) {
+        // 開拓地建設
+        if (canBuild(player, "settlement")) {
+          const validIntersections = getValidSettlementLocations(state, playerId, false);
+          for (const intersection of validIntersections) {
+            actions.push({
+              type: "build_settlement",
+              description: `開拓地を建設 (位置: ${intersection.id})`,
+              params: { intersectionId: intersection.id },
+            });
+          }
+        }
+
+        // 都市建設
+        if (canBuild(player, "city")) {
+          const validCityLocations = getValidCityLocations(state, playerId);
+          for (const intersection of validCityLocations) {
+            actions.push({
+              type: "build_city",
+              description: `都市を建設 (位置: ${intersection.id})`,
+              params: { intersectionId: intersection.id },
+            });
+          }
+        }
+
+        // 道建設
+        if (canBuild(player, "road")) {
+          const validEdges = getValidRoadLocations(state, playerId);
+          for (const edge of validEdges.slice(0, 10)) {
+            actions.push({
+              type: "build_road",
+              description: `道を建設 (位置: ${edge.id})`,
+              params: { edgeId: edge.id },
+            });
+          }
+        }
+
+        // 発展カード購入
+        if (
+          canBuild(player, "developmentCard") &&
+          state.developmentCardDeckCount > 0
+        ) {
+          actions.push({
+            type: "buy_development_card",
+            description: "発展カードを購入",
+          });
+        }
+
+        // 発展カード使用
+        const usableCards = player.developmentCards.filter(
+          (card) =>
+            !state.cardsBoughtThisTurn.includes(card) &&
+            card !== "victoryPoint"
+        );
+        const uniqueCards = [...new Set(usableCards)];
+        for (const cardType of uniqueCards) {
+          actions.push({
+            type: "use_development_card",
+            description: `${getCardName(cardType)}を使用`,
+            params: { cardType },
+          });
+        }
+
+        // 銀行交易
+        const bankTradeOptions = getBankTradeOptions(state, player);
+        for (const option of bankTradeOptions.slice(0, 5)) {
+          actions.push({
+            type: "trade_with_bank",
+            description: `銀行交易: ${option.give.resource}${option.give.amount}枚 → ${option.receive}1枚`,
+            params: option,
+          });
+        }
+
+        // ターン終了
+        actions.push({
+          type: "end_turn",
+          description: "ターンを終了",
+        });
+      }
+      break;
+  }
+
+  return actions;
+}
+
+/**
+ * AIプレイヤーのターンを実行
+ */
+export async function executeAITurn(
+  state: GameState,
+  playerId: string
+): Promise<GameAction | null> {
+  const aiClient = getAIClient();
+  if (!aiClient) {
+    console.error("[AIPlayer] AI client not available");
+    return null;
+  }
+
+  const availableActions = getAvailableActionsForAI(state, playerId);
+  if (availableActions.length === 0) {
+    console.warn("[AIPlayer] No available actions for AI");
+    return null;
+  }
+
+  console.log(
+    `[AIPlayer] ${state.players.find((p) => p.id === playerId)?.name} is deciding...`,
+    `Phase: ${state.phase}, Available actions: ${availableActions.length}`
+  );
+
+  const action = await aiClient.decideAction(state, playerId, availableActions);
+  return action;
+}
+
+// ============================================
+// ヘルパー関数
+// ============================================
+
+function canBuild(
+  player: Player,
+  type: "settlement" | "city" | "road" | "developmentCard"
+): boolean {
+  const cost = BUILD_COSTS[type];
+  for (const [resource, amount] of Object.entries(cost)) {
+    if (player.resources[resource as HoldableResource] < (amount as number)) {
+      return false;
+    }
+  }
+
+  if (type === "settlement" && player.remainingPieces.settlements <= 0) {
+    return false;
+  }
+  if (type === "city" && player.remainingPieces.cities <= 0) {
+    return false;
+  }
+  if (type === "road" && player.remainingPieces.roads <= 0) {
+    return false;
+  }
+
+  return true;
+}
+
+function getValidSettlementLocations(
+  state: GameState,
+  playerId: string,
+  isSetup: boolean
+): Array<{ id: string }> {
+  const validLocations: Array<{ id: string }> = [];
+
+  for (const intersection of state.intersections) {
+    // 既に建物がある場所はスキップ
+    if (intersection.building) continue;
+
+    // 隣接する頂点に建物がないかチェック（2マスルール）
+    const adjacentIntersections = getAdjacentIntersections(state, intersection.id);
+    const hasAdjacentBuilding = adjacentIntersections.some(
+      (adjId) => state.intersections.find((i) => i.id === adjId)?.building
+    );
+    if (hasAdjacentBuilding) continue;
+
+    // 初期配置でなければ、自分の道に隣接している必要がある
+    if (!isSetup) {
+      const adjacentEdges = getAdjacentEdges(state, intersection.id);
+      const hasOwnRoad = adjacentEdges.some(
+        (edgeId) =>
+          state.edges.find((e) => e.id === edgeId)?.road?.playerId === playerId
+      );
+      if (!hasOwnRoad) continue;
+    }
+
+    validLocations.push({ id: intersection.id });
+  }
+
+  return validLocations;
+}
+
+function getValidCityLocations(
+  state: GameState,
+  playerId: string
+): Array<{ id: string }> {
+  return state.intersections
+    .filter(
+      (i) =>
+        i.building?.playerId === playerId && i.building?.type === "settlement"
+    )
+    .map((i) => ({ id: i.id }));
+}
+
+function getValidRoadLocations(
+  state: GameState,
+  playerId: string
+): Array<{ id: string }> {
+  const validLocations: Array<{ id: string }> = [];
+
+  for (const edge of state.edges) {
+    // 既に道がある場所はスキップ
+    if (edge.road) continue;
+
+    // 自分の建物または道に隣接している必要がある
+    const adjacentIntersections = getEdgeAdjacentIntersections(state, edge.id);
+    const adjacentEdges = getEdgeAdjacentEdges(state, edge.id);
+
+    const hasOwnBuilding = adjacentIntersections.some(
+      (intId) =>
+        state.intersections.find((i) => i.id === intId)?.building?.playerId ===
+        playerId
+    );
+    const hasOwnRoad = adjacentEdges.some(
+      (edgeId) =>
+        state.edges.find((e) => e.id === edgeId)?.road?.playerId === playerId
+    );
+
+    if (hasOwnBuilding || hasOwnRoad) {
+      validLocations.push({ id: edge.id });
+    }
+  }
+
+  return validLocations;
+}
+
+function getValidRobberLocations(
+  state: GameState
+): Array<{ id: string; resourceType: string; numberToken: number | null }> {
+  return state.hexes
+    .filter((h) => !h.hasRobber && h.resourceType !== "desert")
+    .map((h) => ({
+      id: h.id,
+      resourceType: h.resourceType,
+      numberToken: h.numberToken,
+    }));
+}
+
+function getStealTargets(
+  state: GameState,
+  robberPlayerId: string
+): Array<{ id: string; name: string }> {
+  const robberHex = state.hexes.find((h) => h.hasRobber);
+  if (!robberHex) return [];
+
+  // 盗賊のいるタイルに隣接する建物を持つプレイヤー
+  const targets = new Set<string>();
+  for (const intersection of state.intersections) {
+    if (
+      intersection.building &&
+      intersection.building.playerId !== robberPlayerId
+    ) {
+      // この頂点が盗賊のタイルに隣接しているかチェック
+      const adjacentHexes = getIntersectionAdjacentHexes(state, intersection.id);
+      if (adjacentHexes.includes(robberHex.id)) {
+        const player = state.players.find(
+          (p) => p.id === intersection.building?.playerId
+        );
+        if (player) {
+          const totalResources = Object.values(player.resources).reduce(
+            (a, b) => a + b,
+            0
+          );
+          if (totalResources > 0) {
+            targets.add(player.id);
+          }
+        }
+      }
+    }
+  }
+
+  return Array.from(targets).map((id) => ({
+    id,
+    name: state.players.find((p) => p.id === id)?.name || "Unknown",
+  }));
+}
+
+function generateDiscardOptions(
+  resources: Record<HoldableResource, number>,
+  discardCount: number
+): Array<Partial<Record<HoldableResource, number>>> {
+  // 簡易的な実装: 最も多い資源から順に破棄
+  const sorted = Object.entries(resources)
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1]);
+
+  const result: Partial<Record<HoldableResource, number>> = {};
+  let remaining = discardCount;
+
+  for (const [resource, count] of sorted) {
+    if (remaining <= 0) break;
+    const toDiscard = Math.min(count, remaining);
+    result[resource as HoldableResource] = toDiscard;
+    remaining -= toDiscard;
+  }
+
+  return [result];
+}
+
+function getBankTradeOptions(
+  state: GameState,
+  player: Player
+): Array<{ give: { resource: HoldableResource; amount: number }; receive: HoldableResource }> {
+  const options: Array<{ give: { resource: HoldableResource; amount: number }; receive: HoldableResource }> = [];
+  const resources: HoldableResource[] = ["wood", "brick", "wheat", "ore", "sheep"];
+
+  // 各資源について交換レートを計算
+  for (const giveResource of resources) {
+    const tradeRate = getTradeRate(state, player.id, giveResource);
+    if (player.resources[giveResource] >= tradeRate) {
+      for (const receiveResource of resources) {
+        if (giveResource !== receiveResource) {
+          options.push({
+            give: { resource: giveResource, amount: tradeRate },
+            receive: receiveResource,
+          });
+        }
+      }
+    }
+  }
+
+  return options;
+}
+
+function getTradeRate(
+  state: GameState,
+  playerId: string,
+  resource: HoldableResource
+): number {
+  // プレイヤーの建物がある港をチェック
+  let bestRate = 4; // デフォルトは4:1
+
+  for (const intersection of state.intersections) {
+    if (intersection.building?.playerId === playerId && intersection.port) {
+      if (intersection.port.resourceType === resource) {
+        return intersection.port.ratio; // 2:1港
+      }
+      if (intersection.port.resourceType === null) {
+        bestRate = Math.min(bestRate, intersection.port.ratio); // 3:1港
+      }
+    }
+  }
+
+  return bestRate;
+}
+
+function getCardName(cardType: DevelopmentCardType): string {
+  const names: Record<DevelopmentCardType, string> = {
+    knight: "騎士カード",
+    victoryPoint: "勝利点カード",
+    roadBuilding: "街道建設",
+    yearOfPlenty: "収穫",
+    monopoly: "独占",
+  };
+  return names[cardType] || cardType;
+}
+
+// ============================================
+// 隣接関係の取得（簡易実装）
+// 実際にはボードの構造に基づいて計算する必要があります
+// ============================================
+
+function getAdjacentIntersections(
+  state: GameState,
+  intersectionId: string
+): string[] {
+  // 隣接頂点のIDを取得（実装はボード構造に依存）
+  // ここでは簡易的に、IDから座標を解析して隣接を計算
+  const intersection = state.intersections.find((i) => i.id === intersectionId);
+  if (!intersection) return [];
+
+  const adjacent: string[] = [];
+  const coord = intersection.coordinate;
+
+  // 隣接する辺を経由して隣接頂点を探す
+  for (const edge of state.edges) {
+    const edgeCoord = edge.coordinate;
+    // 頂点と辺の隣接関係をチェック
+    if (isEdgeAdjacentToIntersection(edgeCoord, coord)) {
+      // この辺のもう一方の端点を取得
+      for (const otherInt of state.intersections) {
+        if (
+          otherInt.id !== intersectionId &&
+          isEdgeAdjacentToIntersection(edgeCoord, otherInt.coordinate)
+        ) {
+          adjacent.push(otherInt.id);
+        }
+      }
+    }
+  }
+
+  return [...new Set(adjacent)];
+}
+
+function getAdjacentEdges(state: GameState, intersectionId: string): string[] {
+  const intersection = state.intersections.find((i) => i.id === intersectionId);
+  if (!intersection) return [];
+
+  return state.edges
+    .filter((e) => isEdgeAdjacentToIntersection(e.coordinate, intersection.coordinate))
+    .map((e) => e.id);
+}
+
+function getEdgeAdjacentIntersections(
+  state: GameState,
+  edgeId: string
+): string[] {
+  const edge = state.edges.find((e) => e.id === edgeId);
+  if (!edge) return [];
+
+  return state.intersections
+    .filter((i) => isEdgeAdjacentToIntersection(edge.coordinate, i.coordinate))
+    .map((i) => i.id);
+}
+
+function getEdgeAdjacentEdges(state: GameState, edgeId: string): string[] {
+  const edge = state.edges.find((e) => e.id === edgeId);
+  if (!edge) return [];
+
+  // 辺の両端点を取得
+  const endpoints = getEdgeAdjacentIntersections(state, edgeId);
+
+  // 両端点に隣接する他の辺を取得
+  const adjacentEdges: string[] = [];
+  for (const intId of endpoints) {
+    const edges = getAdjacentEdges(state, intId);
+    for (const e of edges) {
+      if (e !== edgeId) {
+        adjacentEdges.push(e);
+      }
+    }
+  }
+
+  return [...new Set(adjacentEdges)];
+}
+
+function getIntersectionAdjacentHexes(
+  state: GameState,
+  intersectionId: string
+): string[] {
+  const intersection = state.intersections.find((i) => i.id === intersectionId);
+  if (!intersection) return [];
+
+  // 頂点に隣接するヘックスを取得
+  return state.hexes
+    .filter((h) => isHexAdjacentToIntersection(h.coordinate, intersection.coordinate))
+    .map((h) => h.id);
+}
+
+// ============================================
+// 座標ベースの隣接判定
+// ============================================
+
+function isEdgeAdjacentToIntersection(
+  edgeCoord: { hex: { q: number; r: number; s: number }; direction: "NE" | "E" | "SE" },
+  intCoord: { hex: { q: number; r: number; s: number }; direction: "N" | "S" }
+): boolean {
+  const eh = edgeCoord.hex;
+  const ih = intCoord.hex;
+
+  // 辺と頂点の隣接パターン
+  if (edgeCoord.direction === "NE") {
+    if (intCoord.direction === "N") {
+      return (eh.q === ih.q && eh.r === ih.r) || (eh.q === ih.q + 1 && eh.r === ih.r - 1);
+    } else {
+      return eh.q === ih.q + 1 && eh.r === ih.r;
+    }
+  } else if (edgeCoord.direction === "E") {
+    if (intCoord.direction === "N") {
+      return eh.q === ih.q + 1 && eh.r === ih.r - 1;
+    } else {
+      return eh.q === ih.q + 1 && eh.r === ih.r;
+    }
+  } else {
+    // SE
+    if (intCoord.direction === "N") {
+      return eh.q === ih.q + 1 && eh.r === ih.r;
+    } else {
+      return (eh.q === ih.q && eh.r === ih.r) || (eh.q === ih.q + 1 && eh.r === ih.r);
+    }
+  }
+}
+
+function isHexAdjacentToIntersection(
+  hexCoord: { q: number; r: number; s: number },
+  intCoord: { hex: { q: number; r: number; s: number }; direction: "N" | "S" }
+): boolean {
+  const h = hexCoord;
+  const ih = intCoord.hex;
+
+  if (intCoord.direction === "N") {
+    // 北向き頂点に隣接するヘックス
+    return (
+      (h.q === ih.q && h.r === ih.r) ||
+      (h.q === ih.q && h.r === ih.r - 1) ||
+      (h.q === ih.q + 1 && h.r === ih.r - 1)
+    );
+  } else {
+    // 南向き頂点に隣接するヘックス
+    return (
+      (h.q === ih.q && h.r === ih.r) ||
+      (h.q === ih.q && h.r === ih.r + 1) ||
+      (h.q === ih.q - 1 && h.r === ih.r + 1)
+    );
+  }
+}

--- a/server/ai/index.ts
+++ b/server/ai/index.ts
@@ -1,0 +1,12 @@
+/**
+ * AI モジュール
+ * CPUプレイヤーの作成・管理・ターン実行
+ */
+
+export { AIClient, getAIClient, isAIAvailable } from "./ai-client";
+export {
+  createCPUPlayer,
+  isAIPlayer,
+  getAvailableActionsForAI,
+  executeAITurn,
+} from "./ai-player";

--- a/server/index.ts
+++ b/server/index.ts
@@ -64,6 +64,13 @@ import {
   resetGameState,
 } from "./game-logic";
 
+import {
+  createCPUPlayer,
+  isAIPlayer,
+  executeAITurn,
+  isAIAvailable,
+} from "./ai";
+
 // ============================================
 // 設定
 // ============================================
@@ -868,6 +875,11 @@ async function handleGameAction(
       console.log(
         `[Server] Game over! Winner: ${gameState.winnerId} in room ${roomId}`
       );
+    } else {
+      // AIプレイヤーのターンを自動実行（遅延を入れて非同期で）
+      setTimeout(() => {
+        executeAITurnIfNeeded(roomId);
+      }, 1000);
     }
   } catch (error) {
     console.error("[Server] Error in handleGameAction:", error);
@@ -1132,6 +1144,351 @@ async function handleResetGame(
 }
 
 /**
+ * CPUプレイヤー追加ハンドラー（ホストのみ）
+ */
+async function handleAddCpuPlayer(
+  socket: Socket<ClientToServerEvents, ServerToClientEvents>,
+  data: { roomId: string }
+): Promise<void> {
+  const { roomId } = data;
+
+  try {
+    const playerId = await getPlayerIdBySocket(socket.id);
+
+    if (!playerId) {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "プレイヤーが見つかりません",
+      });
+      return;
+    }
+
+    // ゲーム状態を取得
+    const gameState = await getGameState(roomId);
+
+    if (!gameState) {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "ゲームが見つかりません",
+      });
+      return;
+    }
+
+    // ホストかどうか確認
+    if (gameState.hostId !== playerId) {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "CPUプレイヤーを追加できるのはホストのみです",
+      });
+      return;
+    }
+
+    // 待機中かどうか確認
+    if (gameState.phase !== "waiting") {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "ゲーム開始後はCPUプレイヤーを追加できません",
+      });
+      return;
+    }
+
+    // AIが利用可能か確認
+    if (!isAIAvailable()) {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "AIが利用できません。サーバー設定を確認してください。",
+      });
+      return;
+    }
+
+    // プレイヤー数チェック
+    if (gameState.players.length >= 4) {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "プレイヤーは最大4人までです",
+      });
+      return;
+    }
+
+    // CPUプレイヤーを作成
+    const cpuPlayer = createCPUPlayer(gameState.players);
+
+    if (!cpuPlayer) {
+      socket.emit("cpu_player_added", {
+        success: false,
+        error: "CPUプレイヤーの作成に失敗しました",
+      });
+      return;
+    }
+
+    // ゲーム状態を更新
+    const newGameState = {
+      ...gameState,
+      players: [...gameState.players, cpuPlayer],
+      updatedAt: new Date().toISOString(),
+    };
+
+    await saveGameState(roomId, newGameState);
+
+    // ルーム情報を更新
+    const existingRoomInfo = await getRoomInfo(roomId);
+    if (existingRoomInfo) {
+      const roomInfo: RoomInfo = {
+        ...existingRoomInfo,
+        playerCount: newGameState.players.length,
+      };
+      await saveRoomInfo(roomId, roomInfo);
+    }
+
+    // 成功を通知
+    socket.emit("cpu_player_added", {
+      success: true,
+      player: cpuPlayer,
+    });
+
+    // ルーム全体に更新された状態を送信
+    await broadcastGameState(roomId, newGameState);
+
+    console.log(
+      `[Server] CPU player ${cpuPlayer.name} added to room ${roomId} by host ${playerId}`
+    );
+  } catch (error) {
+    console.error("[Server] Error in handleAddCpuPlayer:", error);
+    socket.emit("cpu_player_added", {
+      success: false,
+      error: "CPUプレイヤーの追加に失敗しました",
+    });
+  }
+}
+
+/**
+ * CPUプレイヤー削除ハンドラー（ホストのみ）
+ */
+async function handleRemoveCpuPlayer(
+  socket: Socket<ClientToServerEvents, ServerToClientEvents>,
+  data: { roomId: string; playerId: string }
+): Promise<void> {
+  const { roomId, playerId: cpuPlayerId } = data;
+
+  try {
+    const playerId = await getPlayerIdBySocket(socket.id);
+
+    if (!playerId) {
+      socket.emit("cpu_player_removed", {
+        success: false,
+        error: "プレイヤーが見つかりません",
+      });
+      return;
+    }
+
+    // ゲーム状態を取得
+    const gameState = await getGameState(roomId);
+
+    if (!gameState) {
+      socket.emit("cpu_player_removed", {
+        success: false,
+        error: "ゲームが見つかりません",
+      });
+      return;
+    }
+
+    // ホストかどうか確認
+    if (gameState.hostId !== playerId) {
+      socket.emit("cpu_player_removed", {
+        success: false,
+        error: "CPUプレイヤーを削除できるのはホストのみです",
+      });
+      return;
+    }
+
+    // 待機中かどうか確認
+    if (gameState.phase !== "waiting") {
+      socket.emit("cpu_player_removed", {
+        success: false,
+        error: "ゲーム開始後はCPUプレイヤーを削除できません",
+      });
+      return;
+    }
+
+    // 対象プレイヤーがCPUか確認
+    const cpuPlayer = gameState.players.find((p) => p.id === cpuPlayerId);
+    if (!cpuPlayer || !isAIPlayer(cpuPlayer)) {
+      socket.emit("cpu_player_removed", {
+        success: false,
+        error: "指定されたプレイヤーはCPUではありません",
+      });
+      return;
+    }
+
+    // CPUプレイヤーを削除
+    const newGameState = {
+      ...gameState,
+      players: gameState.players.filter((p) => p.id !== cpuPlayerId),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await saveGameState(roomId, newGameState);
+
+    // ルーム情報を更新
+    const existingRoomInfo = await getRoomInfo(roomId);
+    if (existingRoomInfo) {
+      const roomInfo: RoomInfo = {
+        ...existingRoomInfo,
+        playerCount: newGameState.players.length,
+      };
+      await saveRoomInfo(roomId, roomInfo);
+    }
+
+    // 成功を通知
+    socket.emit("cpu_player_removed", {
+      success: true,
+      playerId: cpuPlayerId,
+    });
+
+    // ルーム全体に更新された状態を送信
+    await broadcastGameState(roomId, newGameState);
+
+    console.log(
+      `[Server] CPU player ${cpuPlayer.name} removed from room ${roomId} by host ${playerId}`
+    );
+  } catch (error) {
+    console.error("[Server] Error in handleRemoveCpuPlayer:", error);
+    socket.emit("cpu_player_removed", {
+      success: false,
+      error: "CPUプレイヤーの削除に失敗しました",
+    });
+  }
+}
+
+/**
+ * AIプレイヤーのターンを自動実行
+ * ゲーム状態が変わった後に呼び出される
+ */
+async function executeAITurnIfNeeded(roomId: string): Promise<void> {
+  try {
+    let gameState = await getGameState(roomId);
+    if (!gameState) return;
+
+    // ゲームが終了している場合は何もしない
+    if (gameState.phase === "game_over" || gameState.phase === "waiting") {
+      return;
+    }
+
+    // 現在のプレイヤーを取得
+    const currentPlayerId = gameState.currentPlayerId;
+    const currentPlayer = gameState.players.find(
+      (p) => p.id === currentPlayerId
+    );
+
+    // AIプレイヤーでなければ何もしない
+    if (!currentPlayer || !isAIPlayer(currentPlayer)) {
+      // discardフェーズの場合は、破棄が必要なAIプレイヤーをチェック
+      if (gameState.phase === "discard") {
+        await executeAIDiscardIfNeeded(roomId, gameState);
+      }
+      return;
+    }
+
+    console.log(
+      `[Server] Executing AI turn for ${currentPlayer.name} in room ${roomId}`
+    );
+
+    // AIのアクションを実行
+    const action = await executeAITurn(gameState, currentPlayer.id);
+
+    if (!action) {
+      console.error(
+        `[Server] AI ${currentPlayer.name} failed to decide action`
+      );
+      return;
+    }
+
+    // アクションを処理
+    try {
+      gameState = processGameAction(gameState, action, currentPlayer.id);
+    } catch (error) {
+      console.error(
+        `[Server] AI action failed: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      return;
+    }
+
+    // 状態を保存
+    await saveGameState(roomId, gameState);
+
+    // ルーム全体に更新を配信
+    await broadcastGameState(roomId, gameState);
+
+    console.log(
+      `[Server] AI ${currentPlayer.name} executed: ${action.type}`
+    );
+
+    // 次のAIターンがあれば再帰的に実行（少し遅延を入れる）
+    setTimeout(() => {
+      executeAITurnIfNeeded(roomId);
+    }, 500);
+  } catch (error) {
+    console.error("[Server] Error in executeAITurnIfNeeded:", error);
+  }
+}
+
+/**
+ * discardフェーズでAIプレイヤーの破棄を自動実行
+ */
+async function executeAIDiscardIfNeeded(
+  roomId: string,
+  gameState: GameState
+): Promise<void> {
+  // 破棄が必要なAIプレイヤーを探す
+  for (const player of gameState.players) {
+    if (!isAIPlayer(player)) continue;
+
+    const totalResources = Object.values(player.resources).reduce(
+      (a, b) => a + b,
+      0
+    );
+    if (totalResources <= 7) continue;
+
+    console.log(
+      `[Server] AI ${player.name} needs to discard resources in room ${roomId}`
+    );
+
+    // AIのアクションを実行
+    const action = await executeAITurn(gameState, player.id);
+
+    if (!action) {
+      console.error(
+        `[Server] AI ${player.name} failed to decide discard action`
+      );
+      continue;
+    }
+
+    // アクションを処理
+    try {
+      gameState = processGameAction(gameState, action, player.id);
+    } catch (error) {
+      console.error(
+        `[Server] AI discard action failed: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+      continue;
+    }
+
+    // 状態を保存
+    await saveGameState(roomId, gameState);
+
+    // ルーム全体に更新を配信
+    await broadcastGameState(roomId, gameState);
+
+    console.log(`[Server] AI ${player.name} discarded resources`);
+  }
+
+  // 破棄が完了したら次のターンを確認
+  setTimeout(() => {
+    executeAITurnIfNeeded(roomId);
+  }, 500);
+}
+
+/**
  * 切断ハンドラー
  */
 async function handleDisconnect(
@@ -1190,6 +1547,8 @@ io.on("connection", (socket) => {
   socket.on("game_action", (action) => handleGameAction(socket, action));
   socket.on("chat_message", (data) => handleChatMessage(socket, data));
   socket.on("reset_game", (data) => handleResetGame(socket, data));
+  socket.on("add_cpu_player", (data) => handleAddCpuPlayer(socket, data));
+  socket.on("remove_cpu_player", (data) => handleRemoveCpuPlayer(socket, data));
   socket.on("disconnect", () => handleDisconnect(socket));
 
   // エラーハンドリング

--- a/types/game.ts
+++ b/types/game.ts
@@ -175,6 +175,8 @@ export interface Player {
   };
   // 接続状態
   isConnected: boolean;
+  // AIプレイヤーかどうか
+  isAI?: boolean;
 }
 
 /**
@@ -326,6 +328,10 @@ export interface ClientToServerEvents {
   chat_message: (data: { roomId: string; message: string }) => void;
   // ゲームリセット（ホストのみ）
   reset_game: (data: { roomId: string }) => void;
+  // CPUプレイヤー追加（ホストのみ）
+  add_cpu_player: (data: { roomId: string }) => void;
+  // CPUプレイヤー削除（ホストのみ）
+  remove_cpu_player: (data: { roomId: string; playerId: string }) => void;
 }
 
 /**
@@ -401,6 +407,18 @@ export interface ServerToClientEvents {
   game_reset: (data: { gameState: GameState }) => void;
   // エラー通知
   error: (data: { message: string; code: string }) => void;
+  // CPUプレイヤー追加結果
+  cpu_player_added: (data: {
+    success: boolean;
+    player?: Player;
+    error?: string;
+  }) => void;
+  // CPUプレイヤー削除結果
+  cpu_player_removed: (data: {
+    success: boolean;
+    playerId?: string;
+    error?: string;
+  }) => void;
 }
 
 // ============================================
@@ -679,4 +697,51 @@ export interface TestScenario {
    * 順番に消費され、空になったら通常のランダム処理にフォールバック
    */
   stealIndices?: number[];
+}
+
+// ============================================
+// AI設定
+// ============================================
+
+/**
+ * AIプロバイダーの種類
+ */
+export type AIProvider = "gemini" | "deepseek";
+
+/**
+ * AI設定
+ */
+export interface AIConfig {
+  provider: AIProvider;
+  apiKey: string;
+  // モデル名（オプション、デフォルトは各プロバイダーの推奨モデル）
+  model?: string;
+  // 思考時間（ミリ秒）- 人間らしさのための遅延
+  thinkingDelay?: number;
+}
+
+/**
+ * AIのアクション決定リクエスト
+ */
+export interface AIDecisionRequest {
+  gameState: GameState;
+  playerId: string;
+  availableActions: AvailableAction[];
+}
+
+/**
+ * 実行可能なアクション情報
+ */
+export interface AvailableAction {
+  type: GameActionType;
+  description: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * AIのアクション決定レスポンス
+ */
+export interface AIDecisionResponse {
+  action: GameAction;
+  reasoning?: string;
 }

--- a/types/game.ts
+++ b/types/game.ts
@@ -706,7 +706,7 @@ export interface TestScenario {
 /**
  * AIプロバイダーの種類
  */
-export type AIProvider = "gemini" | "deepseek";
+export type AIProvider = "gemini" | "deepseek" | "openrouter";
 
 /**
  * AI設定


### PR DESCRIPTION
- Add isAI field to Player type and AI configuration types
- Implement AI client with Gemini and DeepSeek API support
- Add AI player management logic with available actions calculation
- Add Socket.io events for adding/removing CPU players
- Implement automatic AI turn execution during gameplay
- Add CPU player button to waiting room UI for hosts
- Display robot icon for CPU players in player panel
- Update .env.example with AI configuration options

The host can now add CPU players (up to 3) during the waiting phase.
CPU players automatically execute their turns using AI API calls.